### PR TITLE
feat: create Person record and /person GET mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Spring-Quickstart-Demo
+
+> Created following https://spring.io/quickstart
+
+### Run the code:
+
+- CLI: `./gradlew bootRun`
+- IDE: Gradle sidebar -> Tasks -> application -> `bootRun`
+
+### Post requests to the server:
+
+Quote: "Spring Boot’s embedded Apache Tomcat server is acting as a webserver and is listening for
+requests on localhost port 8080. Open your browser and in the address bar at the top
+enter http://localhost:8080/hello"

--- a/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
@@ -1,5 +1,6 @@
 package io.github.jason13official.quickstart_demo;
 
+import io.github.jason13official.quickstart_demo.impl.Person;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 @RestController
 public class QuickstartDemoApplication {
+
+	// so we don't create a new record every request
+	private static final Person JASON = new Person("Jason", 25);
 
 	public static void main(String[] args) {
 
@@ -32,4 +36,12 @@ public class QuickstartDemoApplication {
 		return String.format("Hello %s!", name);
 	}
 
+	@GetMapping("/person")
+	public String person() {
+		return asH1(JASON.toPrettyString());
+	}
+
+	private static String asH1(String s) {
+		return "<h1>" + s + "</h1>";
+	}
 }

--- a/src/main/java/io/github/jason13official/quickstart_demo/impl/Person.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/impl/Person.java
@@ -11,6 +11,6 @@ public record Person(String name, Integer age) {
   }
 
   public String toPrettyString() {
-    return "$name, age $age".replace("$name", this.name).replace("$age", String.valueOf(this.age));
+    return String.format("%s, age %d", name, age);
   }
 }

--- a/src/main/java/io/github/jason13official/quickstart_demo/impl/Person.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/impl/Person.java
@@ -1,0 +1,16 @@
+package io.github.jason13official.quickstart_demo.impl;
+
+public record Person(String name, Integer age) {
+
+  @Override
+  public String toString() {
+    return "Person{" +
+        "name='" + name + '\'' +
+        ", age=" + age +
+        '}';
+  }
+
+  public String toPrettyString() {
+    return "$name, age $age".replace("$name", this.name).replace("$age", String.valueOf(this.age));
+  }
+}


### PR DESCRIPTION
Added a new record class, Person, that holds a String `name` and and int `age`, with toString override and pretty toString method.

Added a new endpoint to the live server, `/person` which returns the hard-coded Person defined in the main class of the demo. 

Added a private formatting method for displaying an H1 HTML tag instead of raw text