### PR TITLE
feat: rename /person endpoint, create new /person

### DIFF
--- a/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
@@ -36,9 +36,20 @@ public class QuickstartDemoApplication {
 		return String.format("Hello %s!", name);
 	}
 
-	@GetMapping("/person")
-	public String person() {
+	/**
+	 * Returning a hard-coded String representation of a Person object
+	 */
+	@GetMapping("/person/manualSerialization")
+	public String personManual() {
 		return asH1(JASON.toPrettyString());
+	}
+
+	/**
+	 * Returning a new Person object created from passed values (without {@link RequestParam})
+	 */
+	@GetMapping("/person")
+	public Person person(String name, Integer age) {
+		return new Person(name, age);
 	}
 
 	private static String asH1(String s) {


### PR DESCRIPTION
### Changes

- Changed the original `/person` endpoint logic to return from `/person/manualSerialization` instead.

- Created a new `/person` endpoint which returns a raw Person object created from passed arguments; a String `name` and Integer `age`.

### Findings / Discovery

Without using `@RequestParam` annotations for the endpoints parameters, there is no safe alternative/default value, and arguments may be `null` if not filtered or checked properly.

- Arguments for the endpoint's parameters can be passed in the URI/URL of the endpoint, and may be unordered/out of sequence with the underlying data structure (i.e. in our simple example, `age=25&name=Jason` is semantically the same as `name=Jason&age=25`

- Spring/Spring Boot automatically returns a JSON object for us, even though we are returning a Person object! Serialization is being handled for us in a sense.

---

This PR closes #2 