### PR TITLE
Review serialized representations of Arrays, Lists, and Sets

### DIFF
--- a/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
@@ -8,51 +8,49 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * {@link RestController} is for annotating endpoints/port listeners that should be available
- * with web requests (TCP/UDP?)
+ * {@link RestController} is for annotating endpoints/port listeners that should be available with
+ * web requests (TCP/UDP?)
  */
 @SpringBootApplication
 @RestController
 public class QuickstartDemoApplication {
 
-	// so we don't create a new record every request
-	private static final Person JASON = new Person("Jason", 25);
+  // so we don't create a new record every request
+  private static final Person JASON = new Person("Jason", 25);
 
-	public static void main(String[] args) {
+  public static void main(String[] args) {
 
-		// runs the specified source using default settings; DI of default values to create new object
-		SpringApplication.run(QuickstartDemoApplication.class, args);
-	}
+    // runs the specified source using default settings; DI of default values to create new object
+    SpringApplication.run(QuickstartDemoApplication.class, args);
+  }
 
-	/**
-	 * Quite a lot to unpack here...
-	 * <br />
-	 * {@link GetMapping} maps requests to `/hello` (i.e. `http://localhost:8080/hello`)
-	 * <br />
-	 * {@link RequestParam} expects a value, but provides a safe default if no value was passed
-	 */
-	@GetMapping("/hello")
-	public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
-		return String.format("Hello %s!", name);
-	}
+  private static String asH1(String s) {
+    return "<h1>" + s + "</h1>";
+  }
 
-	/**
-	 * Returning a hard-coded String representation of a Person object
-	 */
-	@GetMapping("/person/manualSerialization")
-	public String personManual() {
-		return asH1(JASON.toPrettyString());
-	}
+  /**
+   * Quite a lot to unpack here... <br /> {@link GetMapping} maps requests to `/hello` (i.e.
+   * `http://localhost:8080/hello`) <br /> {@link RequestParam} expects a value, but provides a safe
+   * default if no value was passed
+   */
+  @GetMapping("/hello")
+  public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
+    return String.format("Hello %s!", name);
+  }
 
-	/**
-	 * Returning a new Person object created from passed values (without {@link RequestParam})
-	 */
-	@GetMapping("/person")
-	public Person person(String name, Integer age) {
-		return new Person(name, age);
-	}
+  /**
+   * Returning a hard-coded String representation of a Person object
+   */
+  @GetMapping("/person/manualSerialization")
+  public String personManual() {
+    return asH1(JASON.toPrettyString());
+  }
 
-	private static String asH1(String s) {
-		return "<h1>" + s + "</h1>";
-	}
+  /**
+   * Returning a new Person object created from passed values (without {@link RequestParam})
+   */
+  @GetMapping("/person")
+  public Person person(String name, Integer age) {
+    return new Person(name, age);
+  }
 }

--- a/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/QuickstartDemoApplication.java
@@ -1,6 +1,13 @@
 package io.github.jason13official.quickstart_demo;
 
+import io.github.jason13official.quickstart_demo.impl.Car;
 import io.github.jason13official.quickstart_demo.impl.Person;
+import io.github.jason13official.quickstart_demo.impl.Student;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 @RestController
 public class QuickstartDemoApplication {
+
+  public static Student[] studentsForDemo = new Student[]{
+      new Student(new Person("Jason", 25), false, new Car("Ford", "Ranger")),
+      new Student(new Person("David", 27), true, new Car("Ford", "Maverick")),
+      new Student(new Person("Barry", 29), true, new Car("Ford", "Bronco"))
+  };
 
   // so we don't create a new record every request
   private static final Person JASON = new Person("Jason", 25);
@@ -52,5 +65,29 @@ public class QuickstartDemoApplication {
   @GetMapping("/person")
   public Person person(String name, Integer age) {
     return new Person(name, age);
+  }
+
+  /** Returns a new Student object created from passed values (some of which are primitives) */
+  @GetMapping("/student")
+  public Student student(String name, int age, boolean undergraduate, String carMake, String carModel) {
+    return new Student(new Person(name, age), undergraduate, new Car(carMake, carModel));
+  }
+
+  /** Returns an Array representation of studentsForDemo */
+  @GetMapping("/student/array")
+  public Student[] studentArray() {
+    return studentsForDemo;
+  }
+
+  /** Returns a List representation of studentsForDemo */
+  @GetMapping("/student/list")
+  public List<Student> studentList() {
+    return List.of(studentsForDemo);
+  }
+
+  /** Returns a Set representation of studentsForDemo */
+  @GetMapping("/student/set")
+  public Set<Student> studentSet() {
+    return Set.of(studentsForDemo);
   }
 }

--- a/src/main/java/io/github/jason13official/quickstart_demo/impl/Car.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/impl/Car.java
@@ -1,0 +1,10 @@
+package io.github.jason13official.quickstart_demo.impl;
+
+/**
+ * Used by {@link Student} to denote the make and model of their respective {@link Car} object.
+ *
+ * @param make a {@link String} representing the manufacturer of the {@link Car}
+ * @param model a {@link String} representing the model of the {@link Car}
+ */
+public record Car(String make, String model) {
+}

--- a/src/main/java/io/github/jason13official/quickstart_demo/impl/Student.java
+++ b/src/main/java/io/github/jason13official/quickstart_demo/impl/Student.java
@@ -1,0 +1,15 @@
+package io.github.jason13official.quickstart_demo.impl;
+
+import io.github.jason13official.quickstart_demo.QuickstartDemoApplication;
+
+/**
+ * Used by {@link QuickstartDemoApplication} endpoints for demonstrations of returning arrays,
+ * lists, and sets.
+ *
+ * @param person the underlying {@link Person} object of the student, with a name and age
+ * @param undergraduate whether the student has graduated
+ * @param car the Student's automobile used to get to and from university
+ */
+public record Student(Person person, boolean undergraduate, Car car) {
+
+}


### PR DESCRIPTION
Attached screenshots include reviewing the original `/hello` endpoints with developer tools for Firefox.

Commits involve adding new Car and Student data types, which utilize primitive types for some parameters. Passing null/failing to pass a valid var to the endpoint can result in "Whitelabel errors", where Spring fails to map primitive types to null values.

I've also created the array of students mentioned in #4 , and endpoints to return that array as itself (an array), as a List, or as a Set.

Comparing the JSON returned by each endpoint, I can't discern any difference. Each endpoints returns valid JSON (assuming primitive values were not null), which contains the student array keyed to integer values starting from 0. I'm assuming this might cause issues during de-serialization, or it's left up to the de-serializer to interpret the correct type?

<img width="1919" height="1079" alt="Screenshot_100" src="https://github.com/user-attachments/assets/a41c7ab7-7a1b-44a3-843c-e6a7fc10113e" />
<img width="1919" height="1079" alt="Screenshot_101" src="https://github.com/user-attachments/assets/ecbc7ae0-b4f9-460a-b964-f40665405cc0" />
<img width="1919" height="1079" alt="Screenshot_102" src="https://github.com/user-attachments/assets/72c1d90e-b90a-4db7-82fe-8387a6b701d7" />
<img width="1919" height="1079" alt="Screenshot_103" src="https://github.com/user-attachments/assets/75d06f75-27f3-402c-9db1-36c90b743e70" />
<img width="1919" height="1079" alt="Screenshot_104" src="https://github.com/user-attachments/assets/d3582996-a51a-4a0b-a5e6-626f1bdf2602" />
<img width="1919" height="1079" alt="Screenshot_105" src="https://github.com/user-attachments/assets/a9f8a914-61fd-4f02-8bc5-7b7994d4683f" />

---

This commit closes #4 @davidalayachew 